### PR TITLE
Update hello_world to accept name parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # test-codex
 Repo untuk coba-coba Codex + GPT-5
+
+## Menjalankan aplikasi
+
+1. Jalankan fungsi `hello_world()` dengan nama yang diinginkan:
+
+   ```bash
+   python hello.py <nama>
+   ```
+
+2. Menjalankan unit test:
+
+   ```bash
+   python -m unittest
+   ```

--- a/hello.py
+++ b/hello.py
@@ -1,0 +1,19 @@
+"""Module providing hello_world function."""
+
+from __future__ import annotations
+
+import sys
+
+
+def hello_world(name: str) -> None:
+    """Print greeting from Codex for the given ``name``."""
+
+    print(f"Hello, {name} dari Codex!")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python hello.py <nama>")
+        sys.exit(1)
+
+    hello_world(sys.argv[1])

--- a/test_hello.py
+++ b/test_hello.py
@@ -1,0 +1,17 @@
+import io
+import unittest
+from contextlib import redirect_stdout
+
+import hello
+
+
+class HelloWorldTestCase(unittest.TestCase):
+    def test_hello_world_prints_expected_greeting(self) -> None:
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            hello.hello_world("Budi")
+        self.assertEqual(buffer.getvalue().strip(), "Hello, Budi dari Codex!")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- make `hello_world` accept a name argument and support CLI usage
- adjust the unit test to cover the new greeting format
- update the README instructions to pass a name when running the script

## Testing
- python -m unittest

------
https://chatgpt.com/codex/tasks/task_e_68d4c6999a8c8329a4fcc745a37825a8